### PR TITLE
Changed ArticleCount to be nullable

### DIFF
--- a/src/Zammad.Client/Resources/Ticket.cs
+++ b/src/Zammad.Client/Resources/Ticket.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -89,7 +89,7 @@ namespace Zammad.Client.Resources
         public int? CreateArticleSenderId { get; set; }
 
         [JsonProperty("article_count")]
-        public int ArticleCount { get; set; }
+        public int? ArticleCount { get; set; }
 
         [JsonProperty("escalation_at")]
         public DateTimeOffset? EscalationAt { get; set; }


### PR DESCRIPTION
When i tried using the nuget package to get all the tickets for my organization, i always got a conversion exception for article count, because it was null. I changed article count to be nullable to fix that.